### PR TITLE
Separate file validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ Invoke-MedmComponent `
 
 A wrapper around `Invoke-MedmComponent`. Passes values through to and hard-codes `-ComponentType Solution`
 
+### Confirm-File
+Performs file validation. Pops up the diff tool on completion, and writes out test results in JUnit format. Confirm-File is useful in the case where you have multiple files output by the process under test. You can call Invoke-MedmComponent and then call Confirm-File multiple times (once per file output from the process). 
+
+Internally, Test-MedmComponent and Test-MedmSolution call Confirm-File to validate the test results with a certified file. 
 
 ### Test-MedmComponent
 

--- a/src/hqTestLite.psm1
+++ b/src/hqTestLite.psm1
@@ -1,6 +1,6 @@
 $Global:DefaultMedmProcessAgentPath = "C:\Program Files\Markit Group\Markit EDM_10_2_4_1\CadisProcessAgent.exe"
-$Global:DefaultMedmDbServer = "sqlesmdev"
-$Global:DefaultMedmDbName = "Cadis"
+$Global:DefaultMedmDbServer = "MyDbServer"
+$Global:DefaultMedmDbName = "MyDbName"
 $Global:DefaultBeyondComparePath = ""
 $Global:DefaultSqlScriptType = "Sql Script"
 $Global:DefaultReportFolder = "C:\HqTest\Results"


### PR DESCRIPTION
Added a cmdlet Confirm-File, which allows performing validation in isolation from performing tests.

Repointed Test-MedmComponent and Test-MedmSolution to reuse Confirm-File. Functionality of these two cmdlets remains unchanged.